### PR TITLE
Removed for to commit in kafka consumer

### DIFF
--- a/apf/consumers/kafka.py
+++ b/apf/consumers/kafka.py
@@ -238,5 +238,4 @@ class KafkaConsumer(GenericConsumer):
                     yield deserialized
 
     def commit(self):
-        for message in self.messages:
-            self.consumer.commit(message, asynchronous=False)
+        self.consumer.commit(asynchronous=False)

--- a/tests/consumers/test_kafka.py
+++ b/tests/consumers/test_kafka.py
@@ -38,8 +38,9 @@ class KafkaConsumerMock(unittest.TestCase):
         messages = [MessageMock(self.error)]*num_messages
         return messages
 
-    def commit(self, message):
-        self.assertIsInstance(message,MessageMock)
+    def commit(self, message=None, asynchronous=False):
+        if message is not None:
+            self.assertIsInstance(message,MessageMock)
 
     def unsubscribe(self):
         pass


### PR DESCRIPTION
Removed for in Kafka Consumer Commit, this was making a lot of high speed sync commits and was not being handled very good by the brokers