### PR TITLE
fix kafka producer topic strategy

### DIFF
--- a/apf/core/topic_management.py
+++ b/apf/core/topic_management.py
@@ -59,8 +59,8 @@ class DailyTopicStrategy(GenericTopicStrategy):
     def _remove_old_topics(self, now):
         for topic in self.topics:
             delta = now - topic.date
-            if delta.days >= self.retention_days:
-                self.topics = self.topics[-self.retention_days:]
+            if abs(delta.days) >= self.retention_days:
+                self.topics = self.topics[-self.retention_days :]
 
     def get_topics(self):
         """Get list of topics updated to the current date.

--- a/tests/producers/test_kafka.py
+++ b/tests/producers/test_kafka.py
@@ -4,6 +4,7 @@ from unittest import mock
 import unittest
 import datetime
 
+
 class KafkaProducerMock(unittest.TestCase):
     def __init__(self):
         pass
@@ -11,42 +12,47 @@ class KafkaProducerMock(unittest.TestCase):
     def flush(self):
         pass
 
-    def produce(self, topic, value=None, key=None, partition=None, on_delivery=None, timestamp=None, headers=None):
-        self.assertIsInstance(topic,str)
+    def produce(
+        self,
+        topic,
+        value=None,
+        key=None,
+        partition=None,
+        on_delivery=None,
+        timestamp=None,
+        headers=None,
+    ):
+        self.assertIsInstance(topic, str)
         self.assertIsInstance(value, (str, bytes))
 
-    def poll(self,timeout=0):
-        self.assertIsInstance(timeout, (int,float))
+    def poll(self, timeout=0):
+        self.assertIsInstance(timeout, (int, float))
 
 
-@mock.patch('apf.producers.kafka.Producer', return_value=KafkaProducerMock())
+@mock.patch("apf.producers.kafka.Producer", return_value=KafkaProducerMock())
 class KafkaProducerTest(GenericProducerTest):
     component = KafkaProducer
 
     params = {
-         "PARAMS": {
-            "bootstrap.servers": "kafka1:9092, kafka2:9092"
-            },
-         "TOPIC": "test_topic",
-         "SCHEMA": {
+        "PARAMS": {"bootstrap.servers": "kafka1:9092, kafka2:9092"},
+        "TOPIC": "test_topic",
+        "SCHEMA": {
             "namespace": "test.avro",
             "type": "record",
             "name": "test",
             "fields": [
                 {"name": "key", "type": "string"},
-                {"name": "int",  "type": ["int"]},
-            ]
-        }
+                {"name": "int", "type": ["int"]},
+            ],
+        },
     }
 
     def test_produce(self, producer_mock):
         super().test_produce()
 
-    def test_produce_with_params(self,producer_mock):
+    def test_produce_with_params(self, producer_mock):
         params = {
-            "PARAMS": {
-                "bootstrap.servers": "kafka1:9092, kafka2:9092"
-            },
+            "PARAMS": {"bootstrap.servers": "kafka1:9092, kafka2:9092"},
             "TOPIC": ["topic1", "topic2"],
             "SCHEMA": {
                 "namespace": "test.avro",
@@ -54,28 +60,25 @@ class KafkaProducerTest(GenericProducerTest):
                 "name": "test",
                 "fields": [
                     {"name": "key", "type": "string"},
-                    {"name": "int",  "type": ["int"]},
-                ]
-            }
+                    {"name": "int", "type": ["int"]},
+                ],
+            },
         }
         comp = self.component(params)
-        comp.produce({'key':'value', 'int':1}, key="key1")
+        comp.produce({"key": "value", "int": 1}, key="key1")
 
-    def test_topic_strategy(self,producer_mock):
-        #TODO: Check if topic is changed at certain hour
+    def test_topic_strategy(self, producer_mock):
         now = datetime.datetime.utcnow()
-        tomorrow = now + datetime.timedelta(days=1)
         date_format = "%Y%m%d"
         params = {
-            "PARAMS": {
-                "bootstrap.servers": "kafka1:9092, kafka2:9092"
-            },
+            "PARAMS": {"bootstrap.servers": "kafka1:9092, kafka2:9092"},
             "TOPIC_STRATEGY": {
-                 "CLASS": "apf.core.topic_management.DailyTopicStrategy",
-                 "PARAMS": {
-                     "topic_format": "apf_test_%s",
-                     "date_format": date_format,
-                     "change_hour": now.hour,
+                "CLASS": "apf.core.topic_management.DailyTopicStrategy",
+                "PARAMS": {
+                    "topic_format": "apf_test_%s",
+                    "date_format": date_format,
+                    "change_hour": now.hour,
+                    "retention_days": 1,
                 },
             },
             "SCHEMA": {
@@ -84,9 +87,20 @@ class KafkaProducerTest(GenericProducerTest):
                 "name": "test",
                 "fields": [
                     {"name": "key", "type": "string"},
-                    {"name": "int",  "type": ["int"]},
-                ]
-            }
+                    {"name": "int", "type": ["int"]},
+                ],
+            },
         }
         comp = self.component(params)
-        msj = comp.produce({'key':'value', 'int':1})
+        topic_before = comp.topic
+        self.assertEqual(len(topic_before), 2)
+        comp.produce({"key": "value", "int": 1})
+        self.assertEqual(len(comp.topic), 1)
+        self.assertEqual(comp.topic[0], topic_before[1])
+        params["TOPIC_STRATEGY"]["PARAMS"]["retention_days"] = 2
+        comp = self.component(params)
+        topic_before = comp.topic
+        self.assertEqual(len(topic_before), 2)
+        comp.produce({"key": "value", "int": 1})
+        self.assertEqual(len(comp.topic), 2)
+        self.assertEqual(comp.topic, topic_before)


### PR DESCRIPTION
Topic management was not behaving correctly, storing more topics than specified. This is now fixed.