### PR TITLE
Fix producer with iterable result

### DIFF
--- a/apf/core/step.py
+++ b/apf/core/step.py
@@ -233,7 +233,7 @@ class GenericStep(abc.ABC):
         return result
 
     def _post_produce(self):
-        self.logger.info("Message produced. Begin post production")
+        self.logger.info("Messages produced. Begin post production")
         self.post_produce()
 
     def post_produce(self):
@@ -322,17 +322,15 @@ class GenericStep(abc.ABC):
         return extra_metrics
 
     def produce(self, result: Union[Iterable[Dict[str, Any]], Dict[str, Any]]):
+        n_messages = 0
         if isinstance(result, dict):
-            self.producer.produce(result)
+            to_produce = [result]
         else:
-            try:
-                for prod_message in result:
-                    self.producer.produce(prod_message)
-            except TypeError:
-                self.logger.debug(
-                    "Execute result not iterable or dict. Assuming single message"
-                )
-                self.producer.produce(result)
+            to_produce = result
+        for prod_message in to_produce:
+            self.producer.produce(prod_message)
+            n_messages += 1
+        self.logger.info(f"Produced {n_messages} messages")
 
     def start(self):
         """Start running the step."""

--- a/apf/core/step.py
+++ b/apf/core/step.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 import abc
-from typing import Any, List, Type, Union
+from typing import Any, Dict, Iterable, List, Type, Union
 from apf.consumers import GenericConsumer
 from apf.metrics.prometheus import DefaultPrometheusMetrics, PrometheusMetrics
 from apf.metrics.generic import GenericMetricsProducer
@@ -181,13 +181,15 @@ class GenericStep(abc.ABC):
                 tid = str(tid).upper()
                 self.prometheus_metrics.telescope_id.state(tid)
         preprocessed = self.pre_execute(self.message)
-        return preprocessed or self.message
+        return preprocessed
 
     def pre_execute(self, messages: List[dict]):
-        pass
+        return messages
 
     @abstractmethod
-    def execute(self, messages: List[dict]):
+    def execute(
+        self, messages: List[dict]
+    ) -> Union[Iterable[Dict[str, Any]], Dict[str, Any]]:
         """Execute the logic of the step. This method has to be implemented by
         the instanced class.
 
@@ -198,7 +200,7 @@ class GenericStep(abc.ABC):
         """
         pass
 
-    def _post_execute(self, result: Any):
+    def _post_execute(self, result: Union[Iterable[Dict[str, Any]], Dict[str, Any]]):
         self.logger.info("Processed message. Begin post processing")
         final_result = self.post_execute(result)
         self.metrics["timestamp_sent"] = datetime.datetime.now(datetime.timezone.utc)
@@ -217,15 +219,17 @@ class GenericStep(abc.ABC):
         self.prometheus_metrics.execution_time.observe(time_difference.total_seconds())
         return final_result
 
-    def post_execute(self, result: Any):
+    def post_execute(self, result: Union[Iterable[Dict[str, Any]], Dict[str, Any]]):
         return result
 
-    def _pre_produce(self, result: Any):
+    def _pre_produce(
+        self, result: Union[Iterable[Dict[str, Any]], Dict[str, Any]]
+    ) -> Union[Iterable[Dict[str, Any]], Dict[str, Any]]:
         self.logger.info("Finished all processing. Begin message production")
         message_to_produce = self.pre_produce(result)
         return message_to_produce
 
-    def pre_produce(self, result: Any):
+    def pre_produce(self, result: Union[Iterable[Dict[str, Any]], Dict[str, Any]]):
         return result
 
     def _post_produce(self):
@@ -317,6 +321,19 @@ class GenericStep(abc.ABC):
             extra_metrics["n_messages"] = 1
         return extra_metrics
 
+    def produce(self, result: Union[Iterable[Dict[str, Any]], Dict[str, Any]]):
+        if isinstance(result, dict):
+            self.producer.produce(result)
+        else:
+            try:
+                for prod_message in result:
+                    self.producer.produce(prod_message)
+            except TypeError:
+                self.logger.debug(
+                    "Execute result not iterable or dict. Assuming single message"
+                )
+                self.producer.produce(result)
+
     def start(self):
         """Start running the step."""
         self._pre_consume()
@@ -325,7 +342,7 @@ class GenericStep(abc.ABC):
             result = self.execute(preprocessed_msg)
             result = self._post_execute(result)
             result = self._pre_produce(result)
-            self.producer.produce(result)
+            self.produce(result)
             self._post_produce()
         self._tear_down()
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="apf_base",
-    version="2.0.1",
+    version="2.1.0",
     description="ALeRCE Alert Processing Framework.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/core/test_step.py
+++ b/tests/core/test_step.py
@@ -9,7 +9,7 @@ import pytest
 
 class MockStep(GenericStep):
     def execute(self, _):
-        pass
+        return {}
 
 
 @pytest.fixture
@@ -156,3 +156,14 @@ def test_post_execute(step, mocker):
     post_execute.assert_called_once_with(result)
     assert step.metrics.get("timestamp_sent")
     send_metrics.assert_called()
+
+
+def test_start_with_execute_returning_iterable(basic_config, mocker):
+    class StepWithIterableExecute(GenericStep):
+        def execute(self, _):
+            return [{}]
+
+    write_mock = mocker.patch.object(StepWithIterableExecute, "_write_success")
+    step = StepWithIterableExecute(config=basic_config)
+    step.start()
+    write_mock.assert_called()

--- a/tests/core/test_step_with_prometheus.py
+++ b/tests/core/test_step_with_prometheus.py
@@ -27,7 +27,7 @@ def basic_config():
 
 class MockStep(GenericStep):
     def execute(self, _):
-        pass
+        return {}
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Instead of producing the result as a single message, iterate over the result producing each iteration's value. 

If result is not iterable, produce the result.

If result is dict, produce the result (iterable, but not list-like)