### PR TITLE
Feature: commit after post_execute

### DIFF
--- a/apf/core/step.py
+++ b/apf/core/step.py
@@ -207,10 +207,10 @@ class GenericStep(abc.ABC):
         pass
 
     def _post_execute(self, result: Union[Iterable[Dict[str, Any]], Dict[str, Any]]):
-        if self.commit:
-            self.consumer.commit()
         self.logger.info("Processed message. Begin post processing")
         final_result = self.post_execute(result)
+        if self.commit:
+            self.consumer.commit()
         self.metrics["timestamp_sent"] = datetime.datetime.now(datetime.timezone.utc)
         time_difference = (
             self.metrics["timestamp_sent"] - self.metrics["timestamp_received"]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="apf_base",
-    version="2.1.4",
+    version="2.1.5",
     description="ALeRCE Alert Processing Framework.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Moved down the consumer.commit() operation, after post_execute life cycle call so that you can perform operations on post_execute stage before commiting the message.