### PR TITLE
Limit confluent-kafka version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click>=7.1.1
-confluent-kafka>=1.4.0
+confluent-kafka>=1.4.0,<2.1.0
 fastavro>=0.22.0,<1.5.0
 Jinja2>=2.10.0
 numpydoc>=0.9.0


### PR DESCRIPTION
Nueva versión 2.1.0 (6 de abril) produce una serie de segfaults en los test de integración (al menos para correction_step)