### PR TITLE
Organize loggers

### DIFF
--- a/apf/consumers/generic.py
+++ b/apf/consumers/generic.py
@@ -10,7 +10,7 @@ class GenericConsumer(ABC):
     """
 
     def __init__(self, config=None):
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(f"alerce.{self.__class__.__name__}")
         self.logger.info(f"Creating {self.__class__.__name__}")
         self.config = config
 

--- a/apf/core/step.py
+++ b/apf/core/step.py
@@ -88,7 +88,7 @@ class GenericStep(abc.ABC):
         return {}
 
     def _set_logger(self, level):
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(f"alerce.{self.__class__.__name__}")
         self.logger.setLevel(level)
         self.logger.info(f"Creating {self.__class__.__name__}")
 

--- a/apf/core/step.py
+++ b/apf/core/step.py
@@ -52,10 +52,9 @@ class GenericStep(abc.ABC):
         producer: Type[GenericProducer] = DefaultProducer,
         metrics_sender: Type[GenericMetricsProducer] = DefaultMetricsProducer,
         config: dict = {},
-        level: int = logging.INFO,
         prometheus_metrics: PrometheusMetrics = DefaultPrometheusMetrics(),
     ):
-        self._set_logger(level)
+        self._set_logger()
         self.config = config
         self.consumer = self._get_consumer(consumer)(self.consumer_config)
         self.producer = self._get_producer(producer)(self.producer_config)
@@ -87,9 +86,8 @@ class GenericStep(abc.ABC):
             return self.metrics_config["PARAMS"]
         return {}
 
-    def _set_logger(self, level):
+    def _set_logger(self):
         self.logger = logging.getLogger(f"alerce.{self.__class__.__name__}")
-        self.logger.setLevel(level)
         self.logger.info(f"Creating {self.__class__.__name__}")
 
     def _get_consumer(self, default: Type[GenericConsumer]) -> Type[GenericConsumer]:

--- a/apf/core/templates/step/scripts/run_step.py
+++ b/apf/core/templates/step/scripts/run_step.py
@@ -11,13 +11,18 @@ sys.path.append(PACKAGE_PATH)
 from settings import *
 
 level = logging.INFO
-if 'LOGGING_DEBUG' in locals():
-    if LOGGING_DEBUG:
-        level=logging.DEBUG
+if os.getenv('LOGGING_DEBUG'):
+    level = logging.DEBUG
 
-logging.basicConfig(level=level,
-                    format='%(asctime)s %(levelname)s %(name)s.%(funcName)s: %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S',)
+logger = logging.getLogger("alerce")
+logger.setLevel(level)
+
+fmt = logging.Formatter("%(asctime)s %(levelname)7s %(name)36s: %(message)s", "%Y-%m-%d %H:%M:%S")
+handler = logging.StreamHandler()
+handler.setFormatter(fmt)
+handler.setLevel(level)
+
+logger.addHandler(handler)
 
 
 from {{package_name}} import {{class_name}}
@@ -25,5 +30,5 @@ from {{package_name}} import {{class_name}}
 if PROMETHEUS:
     start_http_server(8000)
 
-step = {{class_name}}(config=STEP_CONFIG,level=level)
+step = {{class_name}}(config=STEP_CONFIG)
 step.start()

--- a/apf/metrics/generic.py
+++ b/apf/metrics/generic.py
@@ -14,7 +14,7 @@ class DateTimeEncoder(json.JSONEncoder):
 class GenericMetricsProducer(abc.ABC):
     def __init__(self, config):
         self.config = config
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(f"alerce.{self.__class__.__name__}")
         self.logger.info(f"Creating {self.__class__.__name__}")
 
     @abc.abstractmethod

--- a/apf/producers/generic.py
+++ b/apf/producers/generic.py
@@ -7,7 +7,7 @@ class GenericProducer(ABC):
     """Generic Producer for Alert Processing Framework."""
 
     def __init__(self, config=None):
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(f"alerce.{self.__class__.__name__}")
         self.logger.info(f"Creating {self.__class__.__name__}")
         self.config = config
         self._key_field = None

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="apf_base",
-    version="2.3.0",
+    version="2.4.0",
     description="ALeRCE Alert Processing Framework.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Cambia los nombres de los loggers por `alerce.*`.

El script sólo setea los nombres que empiezan con `alerce`.

**IMPORTANTE**: Al actualizar los steps actuales, asegurarse que `level` no se pase al constructor del step. Ese argumento está eliminado. También considerar que el script `run_step.py` tiene que ser modificado para setear sólo loggers con `alerce` (ver la versión que está en APF dentro de `apf/core/templates/scripts/run_step.py`)